### PR TITLE
Build the linked detector configuration for the linked-mode runs 

### DIFF
--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -94,28 +94,28 @@ class DAQController():
 
         for det in latest_status.keys():
             # The detector should be INACTIVE
-            if goal_state['tpc']['active'] == 'false':
+            if goal_state[det]['active'] == 'false':
 
-            # The detector is not in IDLE, ERROR or TIMEOUT: it needs to be stopped
-            if latest_status[det]['status'] in active_states:
-                # Check before if the status is UNKNOWN and it is maybe timing out
-                if latest_status[det]['status'] == STATUS.UNKNOWN:
-                    self.log.info("The status of %s is unknown, check timeouts", det)
-                    self.log.debug("Checking %s timeouts", det)
-                    self.CheckTimeouts(detector=det, command='')
-                # Otherwise stop the detector
-                else:
-                    self.log.info("Stopping the %s", det)
-                    self.StopDetectorGently(detector=det)
+                # The detector is not in IDLE, ERROR or TIMEOUT: it needs to be stopped
+                if latest_status[det]['status'] in active_states:
+                    # Check before if the status is UNKNOWN and it is maybe timing out
+                    if latest_status[det]['status'] == STATUS.UNKNOWN:
+                        self.log.info(f"The status of {det} is unknown, check timeouts")
+                        self.log.debug("Checking %s timeouts", det)
+                        self.CheckTimeouts(detector=det, command='')
+                    # Otherwise stop the detector
+                    else:
+                        self.log.info(f"Sending stop command to {det}")
+                        self.StopDetectorGently(detector=det)
                     
                # Deal separately with the TIMEOUT and ERROR statuses, by stopping the detector if needed
                elif latest_status[det]['status'] == STATUS.TIMEOUT:
-                    self.log.info("%s is in timeout, check timeouts", det)
+                    self.log.info(f"The {det} is in timeout, check timeouts")
                     self.log.debug("Checking %s timeouts", det)
                     self.HandleTimeout(detector=det)
 
                elif latest_status[det]['status'] == STATUS.ERROR:
-                   self.log.info("%s has error, sending stop command", det)
+                   self.log.info(f"The {det} has error, sending stop command")
                    self.ControlDetector(command='stop', detector=det, force=self.can_force_stop[det])
                    self.can_force_stop[det]=False
                     
@@ -128,38 +128,38 @@ class DAQController():
             4. the detectors are in some failed state (ERROR) or in TIMEOUT, we need to stop them
         '''
             # The detector should be ACTIVE (RUNNING)
-            if goal_state['tpc']['active'] == 'true':
+            if goal_state[det]['active'] == 'true':
                 if latest_status[det]['status'] == STATUS.RUNNING:
-                    self.log.info("%s is running", det)
+                    self.log.info(f"The {det} is running")
                     self.CheckRunTurnover(detector=det)
                 # ARMED, start the run
                 elif latest_status[det]['status'] == STATUS.ARMED:
-                    self.log.info("The %s is armed, sending start command" det)
+                    self.log.info(f"The {det} is armed, sending start command")
                     self.ControlDetector(command='start', detector=det)
                 # ARMING, check if it is timing out
                 elif latest_status[det]['status'] == STATUS.ARMING:
-                    self.log.info("The %s is arming, check timeouts", det)
+                    self.log.info(f"The {det} is arming, check timeouts")
                     self.log.debug("Checking %s timeouts", det)
                     self.CheckTimeouts(detector=det, command='arm')
                 # UNKNOWN, check if it is timing out
                 elif latest_status[det]['status'] == STATUS.UNKNOWN:
-                    self.log.info("The status of %s is unknown, check timeouts", det)
+                    self.log.info(f"The status of {det} is unknown, check timeouts")
                     self.log.debug("Checking %s timeouts", det)
                     self.CheckTimeouts(detector=det, command='')
                     
                 # Maybe the detector is IDLE, we should arm a run
                 elif latest_status[det]['status'] == STATUS.IDLE:
-                    self.log.info("The %s is idle, sending arm command", det)
+                    self.log.info(f"The {det} is in idle, sending arm command")
                     self.ControlDetector(command='arm', detector=det)
 
                 # Deal separately with the TIMEOUT and ERROR statuses, by stopping the detector if needed
                 elif latest_status[det]['status'] == STATUS.TIMEOUT:
-                    self.log.info("%s is in timeout, check timeouts", det)
+                    self.log.info(f"The {det} is in timeout, check timeouts")
                     self.log.debug("Checking %s timeouts", det)
                     self.HandleTimeout(detector=det)
                 
                 elif latest_status[det]['status'] == STATUS.ERROR:
-                    self.log.info("%s has error, sending stop command", det)
+                    self.log.info(f"The {det} has error, sending stop command")
                     self.ControlDetector(command='stop', detector=det, force=self.can_force_stop[det])
                     self.can_force_stop[det]=False
                     
@@ -222,7 +222,7 @@ class DAQController():
                 hosts = (readers, cc) # we want the cc to delay by 1s
                 # we can safely short the logic here and buy an extra logic cycle
                 self.one_detector_arming = False
-                delay = 0
+                delay = 1
             else: # stop
                 readers, cc = self.mongo.GetConfiguredNodes(detector,
                     self.goal_state['tpc']['link_mv'], self.goal_state['tpc']['link_nv'])

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -219,7 +219,7 @@ class DAQController():
                 hosts = (readers, cc) # we want the cc to delay by 1s
                 # we can safely short the logic here and buy an extra logic cycle
                 self.one_detector_arming = False
-                delay = 1
+                delay = 1.5
             else: # stop
                 readers, cc = self.mongo.GetConfiguredNodes(detector,
                     self.goal_state['tpc']['link_mv'], self.goal_state['tpc']['link_nv'])

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -95,7 +95,6 @@ class DAQController():
         for det in latest_status.keys():
             # The detector should be INACTIVE
             if goal_state[det]['active'] == 'false':
-
                 # The detector is not in IDLE, ERROR or TIMEOUT: it needs to be stopped
                 if latest_status[det]['status'] in active_states:
                     # Check before if the status is UNKNOWN and it is maybe timing out
@@ -107,26 +106,24 @@ class DAQController():
                     else:
                         self.log.info(f"Sending stop command to {det}")
                         self.StopDetectorGently(detector=det)
-                    
                # Deal separately with the TIMEOUT and ERROR statuses, by stopping the detector if needed
-               elif latest_status[det]['status'] == STATUS.TIMEOUT:
+                elif latest_status[det]['status'] == STATUS.TIMEOUT:
                     self.log.info(f"The {det} is in timeout, check timeouts")
                     self.log.debug("Checking %s timeouts", det)
                     self.HandleTimeout(detector=det)
 
-               elif latest_status[det]['status'] == STATUS.ERROR:
+                elif latest_status[det]['status'] == STATUS.ERROR:
                    self.log.info(f"The {det} has error, sending stop command")
                    self.ControlDetector(command='stop', detector=det, force=self.can_force_stop[det])
                    self.can_force_stop[det]=False
-                    
-        '''
-        CASE 2: DETECTORS ARE ACTIVE (RUNNING)
-        There are now 4 possibilities:
-            1. the detectors are already running, we check if the run needs to be reset, otherwise do nothing
-            2. the detectors are in some in-between state (i.e. ARMING, UNKNOWN), we check if they are timing out and wait for some seconds to allow time for the thing to sort itself out
-            3. the detector are not running (IDLE), we need to start them
-            4. the detectors are in some failed state (ERROR) or in TIMEOUT, we need to stop them
-        '''
+            '''
+                CASE 2: DETECTORS ARE ACTIVE (RUNNING)
+                There are now 4 possibilities:
+            	1. the detectors are already running, we check if the run needs to be reset, otherwise do nothing
+            	2. the detectors are in some in-between state (i.e. ARMING, UNKNOWN), we check if they are timing out and wait for some seconds to allow time for the thing to sort itself out
+            	3. the detector are not running (IDLE), we need to start them
+            	4. the detectors are in some failed state (ERROR) or in TIMEOUT, we need to stop them
+            '''
             # The detector should be ACTIVE (RUNNING)
             if goal_state[det]['active'] == 'true':
                 if latest_status[det]['status'] == STATUS.RUNNING:

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -100,8 +100,8 @@ class DAQController():
                     # Check before if the status is UNKNOWN and it is maybe timing out
                     if latest_status[det]['status'] == STATUS.UNKNOWN:
                         self.log.info(f"The status of {det} is unknown, check timeouts")
-                        self.log.debug("Checking %s timeouts", det)
-                        self.CheckTimeouts(detector=det, command='')
+                        self.log.debug(f"Checking the {det} timeouts")
+                        self.CheckTimeouts(detector=det)
                     # Otherwise stop the detector
                     else:
                         self.log.info(f"Sending stop command to {det}")
@@ -109,7 +109,7 @@ class DAQController():
                # Deal separately with the TIMEOUT and ERROR statuses, by stopping the detector if needed
                 elif latest_status[det]['status'] == STATUS.TIMEOUT:
                     self.log.info(f"The {det} is in timeout, check timeouts")
-                    self.log.debug("Checking %s timeouts", det)
+                    self.log.debug(f"Checking the {det} timeouts")
                     self.HandleTimeout(detector=det)
 
                 elif latest_status[det]['status'] == STATUS.ERROR:
@@ -136,13 +136,13 @@ class DAQController():
                 # ARMING, check if it is timing out
                 elif latest_status[det]['status'] == STATUS.ARMING:
                     self.log.info(f"The {det} is arming, check timeouts")
-                    self.log.debug("Checking %s timeouts", det)
+                    self.log.debug(f"Checking the {det} timeouts")
                     self.CheckTimeouts(detector=det, command='arm')
                 # UNKNOWN, check if it is timing out
                 elif latest_status[det]['status'] == STATUS.UNKNOWN:
                     self.log.info(f"The status of {det} is unknown, check timeouts")
-                    self.log.debug("Checking %s timeouts", det)
-                    self.CheckTimeouts(detector=det, command='')
+                    self.log.debug(f"Checking the {det} timeouts")
+                    self.CheckTimeouts(detector=det)
                     
                 # Maybe the detector is IDLE, we should arm a run
                 elif latest_status[det]['status'] == STATUS.IDLE:

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -50,7 +50,7 @@ class DAQController():
         self.log = log
         self.time_between_commands = int(config['DEFAULT']['TimeBetweenCommands'])
         self.can_force_stop={k:True for k in detectors}
-
+        
     def SolveProblem(self, latest_status, goal_state):
         '''
         This is sort of the whole thing that all the other code is supporting
@@ -66,13 +66,10 @@ class DAQController():
                 run in the neutron veto but it is already running a combined run and
                 therefore unavailable. The frontend should prevent many of these cases though.
 
-        The way that works is this. We do everything iteratively. Like if we see that
-        some detector needs to be stopped in order to proceed we issue the stop command
-        then move on. Everything is then re-evaluated once that command runs through.
-
-        I wrote this very verbosely since it's got quite a few different possibilities and
-        after rewriting once I am convinced longer, clearer code is better than terse, efficient
-        code for this particular function. Also I'm hardcoding the detector names. 
+        The way that works is this:
+        A) the detector should be INACTIVE (i.e., IDLE), we stop the detector if the status is in one of the active states
+        B) the detector should be ACTIVE (i.e, RUNNING), we issue the necessary commands to put the system in the RUNNING status
+        C) we deal separately with the ERROR and TIMEOUT statuses, as in the first time we need to promptly stop the detector, and in the second case we need to handle the timeouts.
         '''
 
         # cache these so other functions can see them
@@ -85,160 +82,92 @@ class DAQController():
                 self.error_stop_count[det] = 0
 
         '''
-        CASE 1: DETECTORS ARE INACTIVE
-
-        In our case 'inactive' means 'stopped'. An inactive detector is in its goal state as 
-        long as it isn't doing anything, i.e. not ARMING, ARMED, or RUNNING. We don't care if 
-        it's idle, or in error, or if there's no status at all. We will care about that later
-        if we try to activate it.
+        CASE 1: DETECTORS ARE INACTIVE (IDLE)
+        'Inactive' means 'stopped'. An inactive detector is in its goal state as long as it isn't doing anything, i.e. it is in neither of the active_states.
         '''
-        # 1a - deal with TPC and also with MV and NV, but only if they're linked
-        active_states = [STATUS.ARMING, STATUS.ARMED, STATUS.RUNNING,
-                         STATUS.ERROR, STATUS.UNKNOWN]
-        if goal_state['tpc']['active'] == 'false':
+        active_states = [STATUS.RUNNING, STATUS.ARMED, STATUS.ARMING, STATUS.UNKNOWN]
 
-            # Send stop command if we have to
-            if (
-                    # TPC not in Idle, error, timeout
-                    (latest_status['tpc']['status'] in active_states) or
-                    # MV linked and not in Idle, error, timeout
-                    (latest_status['muon_veto']['status']  in active_states and
-                     goal_state['tpc']['link_mv'] == 'true') or
-                    # NV linked and not in Idle, error, timeout
-                    (latest_status['neutron_veto']['status']  in active_states and
-                     goal_state['tpc']['link_nv'] == 'true')
-            ):
-                self.StopDetectorGently(detector='tpc')
-            elif latest_status['tpc']['status'] == STATUS.TIMEOUT:
-                self.CheckTimeouts('tpc')
+        for det in latest_status.keys():
+            # The detector should be INACTIVE
+            if goal_state['tpc']['active'] == 'false':
 
-        # 1b - deal with MV but only if MV not linked to TPC
-        if goal_state['tpc']['link_mv'] == 'false' and goal_state['muon_veto']['active'] == 'false':
-            if latest_status['muon_veto']['status'] in active_states:
-                self.StopDetectorGently(detector='muon_veto')
-            elif latest_status['muon_veto']['status'] == STATUS.TIMEOUT:
-                self.CheckTimeouts('muon_veto')
-        # 1c - deal with NV but only if NV not linked to TPC
-        if goal_state['tpc']['link_nv'] == 'false' and goal_state['neutron_veto']['active'] == 'false':
-            if latest_status['neutron_veto']['status'] in active_states:
-                self.StopDetectorGently(detector='neutron_veto')
-            elif latest_status['neutron_veto']['status'] == STATUS.TIMEOUT:
-                self.CheckTimeouts('neutron_veto')
-
-        '''
-        CASE 2: DETECTORS ARE ACTIVE
-
-        This will be more complicated.
-        There are now 4 possibilities (each with sub-possibilities and each for different
-        combinations of linked or unlinked detectors):
-         1. The detectors were already running. Here we have to check if the run needs to
-            be reset but otherwise maybe we can just do nothing.
-         2. The detectors were not already running. We have to start them.
-         3. The detectors are in some failed state. We should periodically complain
-         4. The detectors are in some in-between state (i.e. ARMING) and we just need to
-            wait for some seconds to allow time for the thing to sort itself out.
-        '''
-        # 2a - again we consider the TPC first, as well as the cases where the NV/MV are linked
-        if goal_state['tpc']['active'] == 'true':
-
-            # Maybe we have nothing to do except check the run turnover
-            if (
-                    # TPC running!
-                    (latest_status['tpc']['status'] == STATUS.RUNNING) and
-                    # MV either unlinked or running
-                    (latest_status['muon_veto']['status'] == STATUS.RUNNING or
-                     goal_state['tpc']['link_mv'] == 'false') and
-                    # NV either unlinked or running
-                    (latest_status['neutron_veto']['status'] == STATUS.RUNNING or
-                     goal_state['tpc']['link_nv'] == 'false')
-            ):
-                self.CheckRunTurnover('tpc')
-
-            # Maybe we're already ARMED and should start a run
-            elif (
-                    # TPC ARMED
-                    (latest_status['tpc']['status'] == STATUS.ARMED) and
-                    # MV ARMED or UNLINKED
-                    (latest_status['muon_veto']['status'] == STATUS.ARMED or
-                     goal_state['tpc']['link_mv'] == 'false') and
-                    # NV ARMED or UNLINKED
-                    (latest_status['neutron_veto']['status'] == STATUS.ARMED or
-                     goal_state['tpc']['link_nv'] == 'false')):
-                self.log.info("Starting TPC")
-                self.ControlDetector(command='start', detector='tpc')
-
-            # Maybe we're IDLE and should arm a run
-            elif (
-                    # TPC IDLE
-                    (latest_status['tpc']['status'] == STATUS.IDLE) and
-                    # MV IDLE or UNLINKED
-                    (latest_status['muon_veto']['status'] == STATUS.IDLE or
-                     goal_state['tpc']['link_mv'] == 'false') and
-                    # NV IDLE or UNLINKED
-                    (latest_status['neutron_veto']['status'] == STATUS.IDLE or
-                     goal_state['tpc']['link_nv'] == 'false')):
-                self.log.info("Arming TPC")
-                self.ControlDetector(command='arm', detector='tpc')
-
-            elif (
-                    # TPC ARMING
-                    (latest_status['tpc']['status'] == STATUS.ARMING) and
-                    # MV ARMING or UNLINKED
-                    (latest_status['muon_veto']['status'] == STATUS.ARMING or
-                     goal_state['tpc']['link_mv'] == 'false') and
-                    # NV ARMING or UNLINKED
-                    (latest_status['neutron_veto']['status'] == STATUS.ARMING or
-                     goal_state['tpc']['link_nv'] == 'false')):
-                self.CheckTimeouts(detector='tpc', command='arm')
-
-            elif (
-                    # TPC ERROR
-                    (latest_status['tpc']['status'] == STATUS.ERROR) and
-                    # MV ERROR or UNLINKED
-                    (latest_status['muon_veto']['status'] == STATUS.ERROR or
-                     goal_state['tpc']['link_mv'] == 'false') and
-                    # NV ERROR or UNLINKED
-                    (latest_status['neutron_veto']['status'] == STATUS.ERROR or
-                     goal_state['tpc']['link_nv'] == 'false')):
-                self.log.info("TPC has error!")
-                self.ControlDetector(command='stop', detector='tpc',
-                        force=self.can_force_stop['tpc'])
-                self.can_force_stop['tpc']=False
-
-            # Maybe someone is timing out or we're in some weird mixed state
-            # I think this can just be an 'else' because if we're not in some state we're happy
-            # with we should probably check if a reset is in order.
-            # Note that this will be triggered nearly every run during ARMING so it's not a
-            # big deal
-            else:
-                self.log.debug("Checking TPC timeouts")
-                self.CheckTimeouts('tpc')
-
-        # 2b, 2c. In case the MV and/or NV are UNLINKED and ACTIVE we can treat them
-        # in basically the same way.
-        for detector in ['muon_veto', 'neutron_veto']:
-            linked = goal_state['tpc']['link_mv']
-            if detector == 'neutron_veto':
-                linked = goal_state['tpc']['link_nv']
-
-            # Active/unlinked. You your own detector now.
-            if (goal_state[detector]['active'] == 'true' and linked == 'false'):
-
-                # Same logic as before but simpler cause we don't have to check for links
-                if latest_status[detector]['status'] == STATUS.RUNNING:
-                    self.CheckRunTurnover(detector)
-                elif latest_status[detector]['status'] == STATUS.ARMED:
-                    self.ControlDetector(command='start', detector=detector)
-                elif latest_status[detector]['status'] == STATUS.IDLE:
-                    self.ControlDetector(command='arm', detector=detector)
-                elif latest_status[detector]['status'] == STATUS.ERROR:
-                    self.ControlDetector(command='stop', detector=detector,
-                            force=self.can_force_stop[detector])
-                    self.can_force_stop[detector] = False
+            # The detector is not in IDLE, ERROR or TIMEOUT: it needs to be stopped
+            if latest_status[det]['status'] in active_states:
+                # Check before if the status is UNKNOWN and it is maybe timing out
+                if latest_status[det]['status'] == STATUS.UNKNOWN:
+                    self.log.info("The status of %s is unknown, check timeouts", det)
+                    self.log.debug("Checking %s timeouts", det)
+                    self.CheckTimeouts(detector=det, command='')
+                # Otherwise stop the detector
                 else:
-                    self.CheckTimeouts(detector)
+                    self.log.info("Stopping the %s", det)
+                    self.StopDetectorGently(detector=det)
+                    
+               # Deal separately with the TIMEOUT and ERROR statuses, by stopping the detector if needed
+               elif latest_status[det]['status'] == STATUS.TIMEOUT:
+                    self.log.info("%s is in timeout, check timeouts", det)
+                    self.log.debug("Checking %s timeouts", det)
+                    self.HandleTimeout(detector=det)
 
+               elif latest_status[det]['status'] == STATUS.ERROR:
+                   self.log.info("%s has error, sending stop command", det)
+                   self.ControlDetector(command='stop', detector=det, force=self.can_force_stop[det])
+                   self.can_force_stop[det]=False
+                    
+        '''
+        CASE 2: DETECTORS ARE ACTIVE (RUNNING)
+        There are now 4 possibilities:
+            1. the detectors are already running, we check if the run needs to be reset, otherwise do nothing
+            2. the detectors are in some in-between state (i.e. ARMING, UNKNOWN), we check if they are timing out and wait for some seconds to allow time for the thing to sort itself out
+            3. the detector are not running (IDLE), we need to start them
+            4. the detectors are in some failed state (ERROR) or in TIMEOUT, we need to stop them
+        '''
+            # The detector should be ACTIVE (RUNNING)
+            if goal_state['tpc']['active'] == 'true':
+                if latest_status[det]['status'] == STATUS.RUNNING:
+                    self.log.info("%s is running", det)
+                    self.CheckRunTurnover(detector=det)
+                # ARMED, start the run
+                elif latest_status[det]['status'] == STATUS.ARMED:
+                    self.log.info("The %s is armed, sending start command" det)
+                    self.ControlDetector(command='start', detector=det)
+                # ARMING, check if it is timing out
+                elif latest_status[det]['status'] == STATUS.ARMING:
+                    self.log.info("The %s is arming, check timeouts", det)
+                    self.log.debug("Checking %s timeouts", det)
+                    self.CheckTimeouts(detector=det, command='arm')
+                # UNKNOWN, check if it is timing out
+                elif latest_status[det]['status'] == STATUS.UNKNOWN:
+                    self.log.info("The status of %s is unknown, check timeouts", det)
+                    self.log.debug("Checking %s timeouts", det)
+                    self.CheckTimeouts(detector=det, command='')
+                    
+                # Maybe the detector is IDLE, we should arm a run
+                elif latest_status[det]['status'] == STATUS.IDLE:
+                    self.log.info("The %s is idle, sending arm command", det)
+                    self.ControlDetector(command='arm', detector=det)
+
+                # Deal separately with the TIMEOUT and ERROR statuses, by stopping the detector if needed
+                elif latest_status[det]['status'] == STATUS.TIMEOUT:
+                    self.log.info("%s is in timeout, check timeouts", det)
+                    self.log.debug("Checking %s timeouts", det)
+                    self.HandleTimeout(detector=det)
+                
+                elif latest_status[det]['status'] == STATUS.ERROR:
+                    self.log.info("%s has error, sending stop command", det)
+                    self.ControlDetector(command='stop', detector=det, force=self.can_force_stop[det])
+                    self.can_force_stop[det]=False
+                    
         return
+    
+    def HandleTimeout(self, detector):
+        '''
+        Detector already in the TIMEOUT status are directly stopped.
+        '''
+        self.ControlDetector(command='stop', detector=detector)
+        
+        return
+
 
     def StopDetectorGently(self, detector):
         '''

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -254,6 +254,7 @@ class MongoConnect():
             self.latest_status[detector]['rate'] = rate
             self.latest_status[detector]['mode'] = mode
             self.latest_status[detector]['buffer'] = buff
+            self.latest_status[detector]['number'] = run_num
 
 
     def GetWantedState(self):

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -92,12 +92,15 @@ class MongoConnect():
         #                 }
         #  }
         self.latest_status = {}
-        dc = json.loads(config['DEFAULT']['MasterDAQConfig'])
-        for detector in dc.keys():
+        
+        # Cache the detector configuration
+        self.dc = json.loads(config['DEFAULT']['MasterDAQConfig'])
+        
+        for detector in self.dc.keys():
             self.latest_status[detector] = {'readers': {}, 'controller': {}}
-            for reader in dc[detector]['readers']:
+            for reader in self.dc[detector]['readers']:
                 self.latest_status[detector]['readers'][reader] = {}
-            for controller in dc[detector]['controller']:
+            for controller in self.dc[detector]['controller']:
                 if controller == "":
                     continue
                 self.latest_status[detector]['controller'][controller] = {}

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -127,8 +127,11 @@ class MongoConnect():
         self.Quit()
 
     def GetUpdate(self, detector_config):
-      
-        self.latest_status = {}
+        self.latest_status = {
+		'tpc':{'controller': {}, 'readers':{}},
+		'muon_veto': {'controller':{}, 'readers':{}},
+		'neutron_veto' : {'controller':{}, 'readers':{}}
+	}
         try:
             for detector in detector_config.keys():
                 for host in detector_config[detector]['readers'].keys():
@@ -423,9 +426,9 @@ class MongoConnect():
         cc = []
         hostlist = []
         for b in doc['boards']:
-            if 'V17' in b['type'] and b['host'] not in hostlist:
+            if 'f17' in b['type'] and b['host'] not in hostlist:
                 hostlist.append(b['host'])
-            elif b['type'] == 'V2718' and b['host'] not in cc:
+            elif b['type'] == 'f2718' and b['host'] not in cc:
                 cc.append(b['host'])
         return hostlist, cc
 

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -123,16 +123,16 @@ class MongoConnect():
     def __del__(self):
         self.Quit()
 
-    def GetUpdate(self):
-
-        latest = {}
+    def GetUpdate(self, detector_config):
+      
+        self.latest_status = {}
         try:
-            for detector in self.latest_status.keys():
-                for host in self.latest_status[detector]['readers'].keys():
+            for detector in detector_config.keys():
+                for host in detector_config[detector]['readers'].keys():
                     doc = self.collections['node_status'].find_one({'host': host},
                                                                    sort=[('_id', -1)])
                     self.latest_status[detector]['readers'][host] = doc
-                for host in self.latest_status[detector]['controller'].keys():
+                for host in detector_config[detector]['controller'].keys():
                     doc = self.collections['node_status'].find_one({'host': host},
                                                                     sort=[('_id', -1)])
                     self.latest_status[detector]['controller'][host] = doc

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -286,7 +286,90 @@ class MongoConnect():
             return self.latest_settings
         except:
             return None
-
+          
+    def GetSuperDetector(self, goal_state):
+      '''
+      Get the SD configuration on the base
+      of the latest linked goal state:
+      - case A: tpc, mv and nv all linked
+      - case B: tpc, mv and nv all un-linked
+      - case C: tpc and mv linked, nv un-linked
+      - case D: tpc and nv linked, mv un-linked
+      '''
+      ###############################################
+      # The format of ret is similar to latest_status
+      ###############################################
+      ret = {}
+      
+      # Case A
+      if goal_state['tpc']['link_mv'] == 'true' and goal_state['tpc']['link_nv'] == 'true':
+        # Return detector
+        ret = {'tpc': {'controller': {}, 'readers': {}}}
+        # Take the nodes of the detectors
+        for detector in self.dc.keys():
+          for cc in self.dc[detector]['controller']:
+            ret['tpc']['controller'][cc] = {}
+          for reader in self.dc[detector]['readers']:
+            ret['tpc']['readers'][reader] = {}
+        return ret
+      
+      # Case B
+      if goal_state['tpc']['link_mv'] == 'false' and goal_state['tpc']['link_nv'] == 'false':
+        # Return the basic detectors configuration
+        for detector in self.dc.keys():
+          ret[detector] = {'controller': {}, 'readers': {}}
+          for cc in self.dc[detector]['controller']:
+            ret[detector]['controller'][cc] = {}
+          for reader in self.dc[detector]['readers']:
+            ret[detector]['readers'][reader] = {}
+        return ret
+      
+      # Case C
+      if goal_state['tpc']['link_mv'] == 'true' and goal_state['tpc']['link_nv'] == 'false':
+        # Return detector
+        ret = {
+          'tpc': {'controller' : {}, 'readers': {} },
+          'neutron_veto': {'controller' : {}, 'readers' : {} }
+        }
+        # Return detector nodes
+        for cc in self.dc['tpc']['controller']:
+          ret['tpc']['controller'][cc] = {}
+        for reader in self.dc['tpc']['readers']:
+          ret['tpc']['readers'][reader] = {}
+        for cc in self.dc['muon_veto']['controller']:
+          ret['tpc']['controller'][cc] = {}
+        for reader in self.dc['muon_veto']['readers']:
+          ret['tpc']['readers'][reader] = {}
+        # Neutron veto nodes
+        for cc in self.dc['neutron_veto']['controller']:
+           ret['neutron_veto']['controller'][cc] = {}
+        for reader in self.dc['neutron_veto']['readers']:
+           ret['neutron_veto']['readers'][reader] = {}
+        return ret
+      
+      # Case D
+      if goal_state['tpc']['link_mv'] == 'false' and goal_state['tpc']['link_nv'] == 'true':
+        # Return detector
+        ret = {
+          'tpc' : {'controller' : {}, 'readers' : {}},
+          'muon_veto' : {'controller' : {}, 'readers' : {}}
+        }
+        # Return detector nodes
+        for cc in self.dc['tpc']['controller']:
+          ret['tpc']['controller'][cc] = {}
+        for reader in self.dc['tpc']['readers']:
+          ret['tpc']['readers'][reader] = {}
+        for cc in self.dc['neutron_veto']['controller']:
+          ret['tpc']['controller'][cc] = {}
+        for reader in self.dc['neutron_veto']['readers']:
+          ret['tpc']['readers'][reader] = {}
+        # Muon veto nodes
+        for cc in self.dc['muon_veto']['controller']:
+          ret['muon_veto']['controller'][cc] = {}
+        for reader in self.dc['muon_veto']['readers']:
+          ret['muon_veto']['readers'][reader] = {}
+        return ret          
+     
     def GetConfiguredNodes(self, detector, link_mv, link_nv):
         '''
         Get the nodes we want from the config file

--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -33,6 +33,9 @@ RetryReset = 3
 # Min time between Stop-Arm and Arm-Start commands
 TimeBetweenCommands = 6
 
+# these are the control keys to look for
+ControlKeys = active comment link_mv link_nv mode softstop stop_after
+
 # Declare detector configuration here. Each detector's top level
 # key is its system-wide name identifier. Under the top-level
 # hosts are fields for the readers and crate controller.

--- a/dispatcher/config_test.ini
+++ b/dispatcher/config_test.ini
@@ -1,0 +1,60 @@
+[DEFAULT]
+
+# Poll frequency in seconds for main program loop. It makes
+# some sense to make other time-based options multiples of
+# this, though not required
+PollFrequency = 3
+
+# How long to wait for boards to arm
+ArmTimeout = 40
+
+# How long since a client's last check-in until we consider
+# it to be 'timing out'
+ClientTimeout = 15
+
+# Database URIs. Please store DB password in the MONGO_PASSWORD
+# environment variable and runs DB password as RUNS_MONGO_PASSWORD
+ControlDatabaseURI = mongodb://daq:%%s@gw:27020/admin
+ControlDatabaseName = daq
+RunsDatabaseURI = mongodb://daq:%%s@gw:27017/admin
+RunsDatabaseName = xenonnt
+RunsDatabaseCollection = runs
+
+# Timeouts (seconds to wait until we assume it failed)
+# Give Arm command some time in case baselines noisy
+ArmCommandTimeout = 60
+# Give start command less time because there's not really anything complicated to do
+StartCommandTimeout = 20
+# Give stop longer in general in case we're writing off a big buffer
+StopCommandTimeout = 30
+# Also retry stop/reset n times before throwing alarm this one is not in seconds
+# but is the number of times to retry (seconds_before_alarm = n*StopCommandTimeout)
+RetryReset = 3
+# Min time between Stop-Arm and Arm-Start commands
+TimeBetweenCommands = 6
+
+# these are the control keys to look for
+ControlKeys = active comment link_mv link_nv mode softstop stop_after
+
+# Declare detector configuration here. Each detector's top level
+# key is its system-wide name identifier. Under the top-level
+# hosts are fields for the readers and crate controller.
+MasterDAQConfig = {
+        "tpc": {
+            "controller": ["reader0_controller_0"],
+            "readers": [
+                "reader0_reader_0",
+                "reader1_reader_0",
+                "reader2_reader_0",
+                "reader3_reader_0"
+            ]
+        },
+        "muon_veto": {
+            "controller": ["reader5_controller_0"],
+            "readers": ["reader5_reader_0"]
+        },
+        "neutron_veto": {
+            "controller": ["reader6_controller_0"],
+            "readers":    ["reader6_reader_0", "reader6_reader_1"]
+        }
+    }

--- a/dispatcher/config_test.ini
+++ b/dispatcher/config_test.ini
@@ -1,5 +1,8 @@
 [DEFAULT]
 
+# Logging name
+LogName = dispatcher_test
+
 # Poll frequency in seconds for main program loop. It makes
 # some sense to make other time-based options multiples of
 # this, though not required

--- a/dispatcher/config_test.ini
+++ b/dispatcher/config_test.ini
@@ -15,9 +15,9 @@ ClientTimeout = 15
 # Database URIs. Please store DB password in the MONGO_PASSWORD
 # environment variable and runs DB password as RUNS_MONGO_PASSWORD
 ControlDatabaseURI = mongodb://daq:%%s@gw:27020/admin
-ControlDatabaseName = daq
-RunsDatabaseURI = mongodb://daq:%%s@gw:27017/admin
-RunsDatabaseName = xenonnt
+ControlDatabaseName = test
+RunsDatabaseURI = mongodb://daq:%%s@gw:27020/admin
+RunsDatabaseName = test
 RunsDatabaseCollection = runs
 
 # Timeouts (seconds to wait until we assume it failed)
@@ -41,20 +41,15 @@ ControlKeys = active comment link_mv link_nv mode softstop stop_after
 # hosts are fields for the readers and crate controller.
 MasterDAQConfig = {
         "tpc": {
-            "controller": ["reader0_controller_0"],
-            "readers": [
-                "reader0_reader_0",
-                "reader1_reader_0",
-                "reader2_reader_0",
-                "reader3_reader_0"
-            ]
+            "controller": ["reader4_controller_0"],
+            "readers": [ "reader4_reader_0"]
         },
         "muon_veto": {
-            "controller": ["reader5_controller_0"],
-            "readers": ["reader5_reader_0"]
+            "controller": ["reader4_controller_1"],
+            "readers": ["reader4_reader_1"]
         },
         "neutron_veto": {
-            "controller": ["reader6_controller_0"],
-            "readers":    ["reader6_reader_0", "reader6_reader_1"]
+            "controller": ["reader4_controller_2"],
+            "readers":    ["reader4_reader_2"]
         }
-    }
+}

--- a/dispatcher/config_test.ini
+++ b/dispatcher/config_test.ini
@@ -55,4 +55,4 @@ MasterDAQConfig = {
             "controller": ["reader4_controller_2"],
             "readers":    ["reader4_reader_2"]
         }
-}
+    }

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -1,7 +1,6 @@
 #!/daq_common/miniconda3/bin/python3
 import configparser
 import argparse
-import logging
 import threading
 import signal
 import datetime
@@ -32,7 +31,7 @@ def main():
     args = parser.parse_args()
     config = configparser.ConfigParser()
     config.read(args.config)
-    logger = get_daq_logger('dispatcher', level = getattr(logging, args.log))
+    logger = get_daq_logger(config['DEFAULT']['LogName'], level = args.log)
     # Declare database object
     MongoConnector = MongoConnect(config, logger)
 
@@ -55,10 +54,7 @@ def main():
             continue
         latest_status = MongoConnector.latest_status
 
-        # TODO: Hypervisor here? 
-        
         # Print an update
-        # TODO: print the current_config and the latest_status 
         for detector in latest_status.keys():
             state = 'ACTIVE' if goal_state[detector]['active'] == 'true' else 'INACTIVE'
             msg = (f'The {detector} should be {state} and is '

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -100,17 +100,24 @@ def main():
     sh = SignalHandler()
 
     while(sh.event.is_set() == False):
-        # Get most recent check-in from all connected hosts
-        if MongoConnector.GetUpdate():
-            continue
-        latest_status = MongoConnector.latest_status
-
+        
         # Get most recent goal state from database. Users will update this from the website.
         goal_state = MongoConnector.GetWantedState()
         if goal_state is None:
             continue
+            
+        # Get the Super-Detector configuration
+        current_config = MongoConnector.GetSuperDetector(goal_state)
+        
+        # Get most recent check-in from all connected hosts
+        if MongoConnector.GetUpdate(current_config):
+            continue
+        latest_status = MongoConnector.latest_status
 
+        # TODO: Hypervisor here? 
+        
         # Print an update
+        # TODO: print the current_config and the latest_status 
         for detector in latest_status.keys():
             logger.debug("Detector %s should be %sACTIVE and is %s"%(
                     detector, '' if goal_state[detector]['active'] == 'true' else 'IN',

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -26,7 +26,7 @@ def main():
     # Parse command line
     parser = argparse.ArgumentParser(description='Manage the DAQ')
     parser.add_argument('--config', type=str, help='Path to your configuration file',
-            default='config.ini')
+            default='config_test.ini')
     parser.add_argument('--log', type=str, help='Logging level', default='DEBUG',
             choices=['DEBUG','INFO','WARNING','ERROR','CRITICAL'])
     args = parser.parse_args()
@@ -44,15 +44,12 @@ def main():
     sh = SignalHandler()
 
     while(sh.event.is_set() == False):
-        
         # Get most recent goal state from database. Users will update this from the website.
         goal_state = MongoConnector.GetWantedState()
         if goal_state is None:
             continue
-            
         # Get the Super-Detector configuration
         current_config = MongoConnector.GetSuperDetector(goal_state)
-        
         # Get most recent check-in from all connected hosts
         if MongoConnector.GetUpdate(current_config):
             continue

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -1,11 +1,12 @@
+#!/daq_common/miniconda3/bin/python3
 import configparser
 import argparse
 import logging
-import logging.handlers
 import threading
 import signal
 import datetime
 import os
+from daqnt import get_daq_logger
 
 from MongoConnect import MongoConnect
 from DAQController import DAQController, STATUS
@@ -20,61 +21,6 @@ class SignalHandler(object):
     def interrupt(self, *args):
         self.event.set()
 
-class LogHandler(logging.Handler):
-    def __init__(self, logdir='/live_data/redax_logs/', retention=0):
-        logging.Handler.__init__(self)
-        self.today = datetime.date.today()
-        self.logdir = logdir
-        self.retention = retention
-        self.Rotate(self.today)
-        self.count = 0
-
-    def close(self):
-        if not self.f.closed:
-            self.f.flush()
-            self.f.close()
-
-    def __del__(self):
-        self.close()
-
-    def emit(self, record):
-        msg_today = datetime.date.fromtimestamp(record.created)
-        msg_datetime = datetime.datetime.fromtimestamp(record.created)
-        if msg_today != self.today:
-            self.Rotate(msg_today)
-        m = self.FormattedMessage(msg_datetime, record.levelname, record.msg)
-        self.f.write(m)
-        print(m[:-1]) # strip \n
-        self.count += 1
-        if self.count > 2:
-            self.f.flush()
-            self.count = 0
-
-    def Rotate(self, when):
-        if hasattr(self, 'f'):
-            self.f.close()
-        self.f = open(self.FullFilename(when), 'a')
-        if self.retention == 0:
-            return
-        last_file = when - datetime.timedelta(days=self.retention)
-        if os.path.exists(self.FullFilename(last_file)):
-            os.remove(self.FullFilename(last_file))
-            m=self.FormattedMessage(datetime.datetime.utcnow(), "init", "Deleting " + self.Filename(last_file))
-        else:
-            m=self.FormattedMessage(datetime.datetime.utcnow(), "init", "No older file to delete :(")
-        self.f.write(m)
-        self.today = datetime.date.today()
-
-    def FullFilename(self, when):
-        return os.path.join(self.logdir, self.Filename(when))
-
-    def Filename(self, when):
-        return f"{when.year:04d}{when.month:02d}{when.day:02d}_dispatcher.log"
-
-    def FormattedMessage(self, when, level, msg):
-        return f"{when.isoformat()} | [{str(level).upper()}] | {msg}\n"
-
-
 def main():
 
     # Parse command line
@@ -86,9 +32,7 @@ def main():
     args = parser.parse_args()
     config = configparser.ConfigParser()
     config.read(args.config)
-    logger = logging.getLogger('main')
-    logger.addHandler(LogHandler())
-    logger.setLevel(getattr(logging, args.log))
+    logger = get_daq_logger('dispatcher', level = getattr(logging, args.log))
     # Declare database object
     MongoConnector = MongoConnect(config, logger)
 
@@ -119,9 +63,12 @@ def main():
         # Print an update
         # TODO: print the current_config and the latest_status 
         for detector in latest_status.keys():
-            logger.debug("Detector %s should be %sACTIVE and is %s"%(
-                    detector, '' if goal_state[detector]['active'] == 'true' else 'IN',
-                    latest_status[detector]['status'].name))
+            state = 'ACTIVE' if goal_state[detector]['active'] == 'true' else 'INACTIVE'
+            msg = (f'The {detector} should be {state} and is '
+                   f'{latest_status[detector]["status"].name}')
+            if latest_status[detector]['number'] != -1:
+                msg += f' ({latest_status[detector]["number"]})'
+            logger.debug(msg)
 
         # Decision time. Are we actually in our goal state? If not what should we do?
         DAQControl.SolveProblem(latest_status, goal_state)


### PR DESCRIPTION
In the code, "Super Detector" refers to one of the four possible linked mode configurations of the tpc and its vetos:
- tpc, muon_veto and neutron_veto all linked (case A)
- tpc, muon_veto and neutron_veto all un-linked (case B)
- tpc and muon_veto linked, neutron_veto un-linked (case C)
- tpc and neutron_veto linked, muon_veto un-linked (case D)

The configuration is built in the function `GetSuperDetector` (file `MongoConnect.py`) on the base of the most recent linked goal state set by the users. Then, it is used in the dispatcher logic flow (`dispatcher.py`) to get the most recent updates of all the connected hosts.